### PR TITLE
Add additional coverage for partition and number utilities

### DIFF
--- a/tests/array/partition.test.ts
+++ b/tests/array/partition.test.ts
@@ -7,4 +7,46 @@ describe("partition", () => {
     expect(even).toEqual([2, 4, 6]);
     expect(odd).toEqual([1, 3, 5]);
   });
+
+  test("returns empty tuples for empty input", () => {
+    const source: number[] = [];
+    const [pass, fail] = partition(source, (value) => value > 0);
+
+    expect(pass).toEqual([]);
+    expect(fail).toEqual([]);
+    expect(source).toEqual([]);
+  });
+
+  test("preserves original ordering in both buckets", () => {
+    const values = [
+      { id: 1, active: true },
+      { id: 2, active: false },
+      { id: 3, active: true },
+      { id: 4, active: false },
+    ];
+
+    const [active, inactive] = partition(values, (item) => item.active);
+
+    expect(active).toEqual([
+      { id: 1, active: true },
+      { id: 3, active: true },
+    ]);
+    expect(inactive).toEqual([
+      { id: 2, active: false },
+      { id: 4, active: false },
+    ]);
+    expect(values).toEqual([
+      { id: 1, active: true },
+      { id: 2, active: false },
+      { id: 3, active: true },
+      { id: 4, active: false },
+    ]);
+  });
+
+  test("handles predicates that always return the same value", () => {
+    const items = ["a", "b", "c"];
+
+    expect(partition(items, () => true)).toEqual([["a", "b", "c"], []]);
+    expect(partition(items, () => false)).toEqual([[], ["a", "b", "c"]]);
+  });
 });

--- a/tests/numbers/mapRange.test.ts
+++ b/tests/numbers/mapRange.test.ts
@@ -13,4 +13,28 @@ describe("mapRange", () => {
       mapRange(10, { fromMin: 0, fromMax: 10, toMin: 0, toMax: 100 })
     ).toBe(100);
   });
+
+  test("maps values when target range is reversed", () => {
+    expect(
+      mapRange(0, { fromMin: 0, fromMax: 10, toMin: 100, toMax: 0 })
+    ).toBe(100);
+    expect(
+      mapRange(10, { fromMin: 0, fromMax: 10, toMin: 100, toMax: 0 })
+    ).toBe(0);
+    expect(
+      mapRange(2.5, { fromMin: 0, fromMax: 10, toMin: 100, toMax: 0 })
+    ).toBe(75);
+  });
+
+  test("handles negative source ranges and extrapolated values", () => {
+    expect(
+      mapRange(-5, { fromMin: -10, fromMax: 0, toMin: 0, toMax: 1 })
+    ).toBe(0.5);
+    expect(
+      mapRange(-15, { fromMin: -10, fromMax: 0, toMin: 0, toMax: 1 })
+    ).toBe(-0.5);
+    expect(
+      mapRange(5, { fromMin: -10, fromMax: 0, toMin: 0, toMax: 1 })
+    ).toBe(1.5);
+  });
 });

--- a/tests/numbers/percentageDifference.test.ts
+++ b/tests/numbers/percentageDifference.test.ts
@@ -8,4 +8,16 @@ describe("percentageDifference", () => {
       Math.abs(percentageDifference(150, 100) - -33.333_333_333_333_33)
     ).toBeLessThan(0.000_000_000_000_1);
   });
+
+  test("handles zero baseline", () => {
+    expect(percentageDifference(0.1, 0)).toBe(-100);
+    expect(percentageDifference(0, 10)).toBe(Infinity);
+    expect(percentageDifference(0, -10)).toBe(-Infinity);
+  });
+
+  test("works with negative baselines", () => {
+    expect(percentageDifference(-100, -150)).toBe(50);
+    expect(percentageDifference(-100, -50)).toBe(-50);
+    expect(percentageDifference(-200, 100)).toBe(-150);
+  });
 });


### PR DESCRIPTION
## Summary
- add edge-case scenarios to the partition tests, including empty input and predicate extremes
- extend mapRange coverage to reversed target ranges and negative/extrapolated inputs
- verify percentageDifference behavior for zero and negative baselines

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68d6a494f024832aa6ad3e7fe5164346