### PR TITLE
Remove object export entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://badge.fury.io/js/utilon.svg)](https://badge.fury.io/js/utilon)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A comprehensive TypeScript utility library with zero dependencies. Utilon provides type-safe, well-tested utility functions for arrays, strings, numbers, dates, and objects.
+A comprehensive TypeScript utility library with zero dependencies. Utilon provides type-safe, well-tested utility functions for arrays, strings, numbers, and dates.
 
 ## ✨ Features
 

--- a/package.json
+++ b/package.json
@@ -36,10 +36,6 @@
       "import": "./dist/array/index.js",
       "types": "./dist/array/index.d.ts"
     },
-    "./object": {
-      "import": "./dist/object/index.js",
-      "types": "./dist/object/index.d.ts"
-    },
     "./package.json": "./package.json"
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary
- remove the unused `./object` subpath export from the package manifest
- update the README introduction so it only lists the available utility modules

## Testing
- bun run build

------
https://chatgpt.com/codex/tasks/task_e_68d6a74b0b5c832a896a9f8cb6000c9a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated docs to clarify that object utilities are no longer included; utilities now cover arrays, strings, numbers, and dates.
* **Chores**
  * Removed the public export for object-related utilities from the package distribution, reducing available module entry points and access to object utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->