### PR TITLE
Handle zero-total percentage calculations

### DIFF
--- a/src/numbers/percentage.util.ts
+++ b/src/numbers/percentage.util.ts
@@ -4,6 +4,7 @@
  * @param value - The value to calculate percentage for
  * @param total - The total value
  * @returns The percentage (0-100)
+ * @throws {Error} If the total is zero, because percentages cannot be derived from a zero total.
  *
  * @example
  * ```ts
@@ -12,5 +13,10 @@
  * percentage(50, 200) // 25
  * ```
  */
-export const percentage = (value: number, total: number): number =>
-  (value / total) * 100;
+export const percentage = (value: number, total: number): number => {
+  if (total === 0) {
+    throw new Error("Cannot calculate percentage: total must not be zero.");
+  }
+
+  return (value / total) * 100;
+};

--- a/tests/numbers/percentage.test.ts
+++ b/tests/numbers/percentage.test.ts
@@ -7,4 +7,10 @@ describe("percentage", () => {
     expect(percentage(1, 4)).toBe(25);
     expect(percentage(0, 100)).toBe(0);
   });
+
+  test("throws when total is zero", () => {
+    expect(() => percentage(10, 0)).toThrow(
+      "Cannot calculate percentage: total must not be zero.",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- prevent division by zero in `percentage` by throwing when the total is zero
- document the zero-total behavior in the JSDoc comment
- add a regression test covering the zero-total error case

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d6a74c3fec832ab99492cc169f28ec