### PR TITLE
Add guard for zero-width mapRange source range

### DIFF
--- a/src/numbers/mapRange.util.ts
+++ b/src/numbers/mapRange.util.ts
@@ -7,6 +7,7 @@
  * @param toMin - The minimum value of the output range
  * @param toMax - The maximum value of the output range
  * @returns The mapped value in the new range
+ * @throws {RangeError} If the source range has zero width (i.e. `fromMax` equals `fromMin`).
  *
  * @example
  * ```ts
@@ -22,5 +23,12 @@ export const mapRange = (
     toMin,
     toMax,
   }: { fromMin: number; fromMax: number; toMin: number; toMax: number }
-): number =>
-  toMin + ((value - fromMin) * (toMax - toMin)) / (fromMax - fromMin);
+): number => {
+  if (fromMax === fromMin) {
+    throw new RangeError(
+      "mapRange source range must have a non-zero width (fromMax !== fromMin)."
+    );
+  }
+
+  return toMin + ((value - fromMin) * (toMax - toMin)) / (fromMax - fromMin);
+};

--- a/tests/numbers/mapRange.test.ts
+++ b/tests/numbers/mapRange.test.ts
@@ -13,4 +13,12 @@ describe("mapRange", () => {
       mapRange(10, { fromMin: 0, fromMax: 10, toMin: 0, toMax: 100 })
     ).toBe(100);
   });
+
+  test("throws when the source range has zero width", () => {
+    expect(() =>
+      mapRange(5, { fromMin: 1, fromMax: 1, toMin: 0, toMax: 100 })
+    ).toThrowError(
+      "mapRange source range must have a non-zero width (fromMax !== fromMin)."
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- throw a descriptive RangeError when mapRange is called with a zero-width source range
- document the guard behaviour in the mapRange JSDoc and add a unit test covering it

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d6a74d3120832a8f97a1b9ef49fa67