### PR TITLE
Handle zero baseline in percentageDifference

### DIFF
--- a/src/numbers/percentageDifference.util.ts
+++ b/src/numbers/percentageDifference.util.ts
@@ -4,6 +4,8 @@
  * @param value1 - The first value (baseline)
  * @param value2 - The second value
  * @returns The percentage difference ((value2 - value1) / value1 * 100)
+ * @throws Will throw an error if the baseline (`value1`) is zero because the
+ * calculation is undefined.
  *
  * @example
  * ```ts
@@ -12,5 +14,10 @@
  * percentageDifference(50, 50) // 0 (no change)
  * ```
  */
-export const percentageDifference = (value1: number, value2: number): number =>
-  ((value2 - value1) / value1) * 100;
+export const percentageDifference = (value1: number, value2: number): number => {
+  if (value1 === 0) {
+    throw new Error("Cannot calculate percentage difference with a zero baseline");
+  }
+
+  return ((value2 - value1) / value1) * 100;
+};

--- a/tests/numbers/percentageDifference.test.ts
+++ b/tests/numbers/percentageDifference.test.ts
@@ -8,4 +8,10 @@ describe("percentageDifference", () => {
       Math.abs(percentageDifference(150, 100) - -33.333_333_333_333_33)
     ).toBeLessThan(0.000_000_000_000_1);
   });
+
+  test("throws when baseline is zero", () => {
+    expect(() => percentageDifference(0, 100)).toThrow(
+      "Cannot calculate percentage difference with a zero baseline"
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- guard percentageDifference against a zero baseline and throw an explicit error
- document the zero-baseline behavior in the utility JSDoc
- cover the new behavior with a dedicated unit test

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d6a74d9248832aa7a18ae9bddbf2cb