### PR TITLE
Ensure difference returns copy when single array

### DIFF
--- a/src/array/difference.util.ts
+++ b/src/array/difference.util.ts
@@ -15,7 +15,7 @@ export const difference = <T>(...arrays: T[][]): T[] => {
     return [];
   }
   if (arrays.length === 1) {
-    return arrays[0];
+    return [...arrays[0]];
   }
 
   const [first, ...rest] = arrays;

--- a/tests/array/difference.test.ts
+++ b/tests/array/difference.test.ts
@@ -5,6 +5,9 @@ describe("difference", () => {
   test("difference", () => {
     expect(difference([1, 2, 3], [2, 3], [3])).toEqual([1]);
     expect(difference()).toEqual([]);
-    expect(difference([1, 2])).toEqual([1, 2]);
+    const input = [1, 2];
+    const result = difference(input);
+    expect(result).toEqual([1, 2]);
+    expect(result).not.toBe(input);
   });
 });


### PR DESCRIPTION
## Summary
- update the single-array branch of `difference` to return a shallow copy
- add a regression test verifying the copy does not share identity with the input

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d6a74ec6b4832a89f9574f6884cb50